### PR TITLE
Fix outside nav div background

### DIFF
--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -15,7 +15,7 @@
 	}
 </script>
 
-<div class="flex flex-col justify-center px-8">
+<div class="flex flex-col justify-center px-8 bg-gray-50 dark:bg-gray-900">
 	<Nav />
 </div>
 <main class="flex flex-col justify-center px-8 bg-gray-50 dark:bg-gray-900">


### PR DESCRIPTION
Hi @sw-yx! First of all, thank you for this great template!

I was taking a look at the source code and found a small bug when toggling the dark/light mode. The div outside the Nav component didn't have the classes for the background, so the result was mixing the white/gray colors.

![image](https://user-images.githubusercontent.com/4452447/147863854-f649d81b-1a1b-4831-af01-ae3a0a37ceea.png)
