### PR TITLE
Updated allowed poster from hard coded GitHub username to configurable GitHub username

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# SwyxKit: A SvelteKit blog template for devs who learn in public
+# SwyxKit
 
-A lightly opinionated starter for Svelte projects:
+A lightly opinionated starter for SvelteKit blogs:
 
 - SvelteKit + Netlify adapter!
 - Tailwind 3 + Tailwind Typography (with [swyx fixes](https://youtu.be/-FzemNMcOGs))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img height=200 src="https://user-images.githubusercontent.com/6764957/155878641-c13ecdc0-ed2f-458c-88c6-cd34bdb38dae.png" />
+# SwyxKit: A SvelteKit blog template for devs who learn in public
 
 A lightly opinionated starter for Svelte projects:
 
@@ -75,6 +75,8 @@ npm run start
 
 You should be able to deploy this project straight to Netlify as is, just [like this project is](https://app.netlify.com/sites/swyxkit/deploys/).
 
+However, to have new posts show up, you will need to personalize the siteConfig below - take note of `APPROVED_POSTERS_GH_USERNAME` in particular (this is an allowlist of people who can post a blog by opening a github issue, otherwise any rando can blog and thats not good).
+
 [![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/sw-yx/swyxkit)
 
 ## Personalization Configuration
@@ -83,6 +85,7 @@ As you become ready to seriously adopt this, remember to configure `/lib/siteCon
 
 ```js
 export const SITE_URL = 'https://swyxkit.netlify.app';
+export const APPROVED_POSTERS_GH_USERNAME = ['sw-yx']; // IMPORTANT - change this to at least your github username, or add others if you want
 export const GH_USER_REPO = 'sw-yx/swyxkit'; // used for pulling github issues and offering comments
 export const REPO_URL = 'https://github.com/' + GH_USER_REPO;
 export const SITE_TITLE = 'SwyxKit';

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ See https://swyxkit.netlify.app/ (see [Deploy Logs](https://app.netlify.com/site
 ## Users in the wild
 
 - https://swyx.io
-- https://twitter.com/iambenwis/status/1500998985388937216?s=21
+- https://twitter.com/iambenwis/status/1500998985388937216
+- https://twitter.com/lucianoratamero/status/1508832233225867267
+- https://twitter.com/Codydearkland/status/1503822866969595904
 - add yourself here!
 
 ## Key Features and Design Considerations:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"date-fns": "^2.28.0",
+				"node": "^17.7.2",
 				"node-fetch": "^2.6.6",
 				"parse-link-header": "^2.0.0",
 				"prism-themes": "^1.9.0",
@@ -3020,6 +3021,26 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
+		},
+		"node_modules/node": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/node/-/node-17.7.2.tgz",
+			"integrity": "sha512-1hLwQfuA39nUDxCTwKqS8l27E9OEzfAdK5xU4Wcr3h2FrQao6qWNnurgWn4GJn9g6tfHuuupyrBl1lvMLNnecw==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"node-bin-setup": "^1.0.0"
+			},
+			"bin": {
+				"node": "bin/node"
+			},
+			"engines": {
+				"npm": ">=5.0.0"
+			}
+		},
+		"node_modules/node-bin-setup": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.0.tgz",
+			"integrity": "sha512-pTeU6NgUrexiLNtd+AKwvg6cngHMvj5FZ5e2bbv2ogBSIc9yhkXSSaTScfSRZnwHIh5YFmYSYlemLWkiKD7rog=="
 		},
 		"node_modules/node-fetch": {
 			"version": "2.6.7",
@@ -7210,6 +7231,19 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
+		},
+		"node": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/node/-/node-17.7.2.tgz",
+			"integrity": "sha512-1hLwQfuA39nUDxCTwKqS8l27E9OEzfAdK5xU4Wcr3h2FrQao6qWNnurgWn4GJn9g6tfHuuupyrBl1lvMLNnecw==",
+			"requires": {
+				"node-bin-setup": "^1.0.0"
+			}
+		},
+		"node-bin-setup": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.0.tgz",
+			"integrity": "sha512-pTeU6NgUrexiLNtd+AKwvg6cngHMvj5FZ5e2bbv2ogBSIc9yhkXSSaTScfSRZnwHIh5YFmYSYlemLWkiKD7rog=="
 		},
 		"node-fetch": {
 			"version": "2.6.7",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 	"type": "module",
 	"dependencies": {
 		"date-fns": "^2.28.0",
+		"node": "^17.7.2",
 		"node-fetch": "^2.6.6",
 		"parse-link-header": "^2.0.0",
 		"prism-themes": "^1.9.0",

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -2,7 +2,7 @@ import { compile } from 'mdsvex';
 import { dev } from '$app/env';
 import grayMatter from 'gray-matter';
 import fetch from 'node-fetch';
-import { GH_USER_REPO } from './siteConfig';
+import { GH_USER_REPO, GH_USER_NAME } from './siteConfig';
 import parse from 'parse-link-header';
 import slugify from 'slugify';
 
@@ -23,7 +23,7 @@ const rehypePlugins = [
 	]
 ];
 
-const allowedPosters = ['sw-yx'];
+const allowedPosters = [GH_USER_NAME];
 const publishedTags = ['Published'];
 let allBlogposts = [];
 // let etag = null // todo - implmement etag header

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -2,7 +2,7 @@ import { compile } from 'mdsvex';
 import { dev } from '$app/env';
 import grayMatter from 'gray-matter';
 import fetch from 'node-fetch';
-import { GH_USER_REPO, GH_USER_NAME } from './siteConfig';
+import { GH_USER_REPO, APPROVED_POSTERS_GH_USERNAME } from './siteConfig';
 import parse from 'parse-link-header';
 import slugify from 'slugify';
 
@@ -23,7 +23,7 @@ const rehypePlugins = [
 	]
 ];
 
-const allowedPosters = [GH_USER_NAME];
+const allowedPosters = APPROVED_POSTERS_GH_USERNAME; // array of strings of github username
 const publishedTags = ['Published'];
 let allBlogposts = [];
 // let etag = null // todo - implmement etag header

--- a/src/lib/siteConfig.js
+++ b/src/lib/siteConfig.js
@@ -1,4 +1,5 @@
 export const SITE_URL = 'https://swyxkit.netlify.app';
+export const GH_USER_NAME = 'sw-yx'
 export const GH_USER_REPO = 'sw-yx/swyxkit'; // used for pulling github issues and offering comments
 export const REPO_URL = 'https://github.com/' + GH_USER_REPO;
 export const SITE_TITLE = 'SwyxKit';

--- a/src/lib/siteConfig.js
+++ b/src/lib/siteConfig.js
@@ -1,5 +1,5 @@
 export const SITE_URL = 'https://swyxkit.netlify.app';
-export const GH_USER_NAME = 'sw-yx'
+export const APPROVED_POSTERS_GH_USERNAME = ['sw-yx'];
 export const GH_USER_REPO = 'sw-yx/swyxkit'; // used for pulling github issues and offering comments
 export const REPO_URL = 'https://github.com/' + GH_USER_REPO;
 export const SITE_TITLE = 'SwyxKit';


### PR DESCRIPTION
Overview 

This PR is in reference to an issue I found where the `allowedPosters` constant (`src/lib/content.js` line 26) is hardcoded to `swyxkit`. If someone downloads this to mess with locally, it is not a big deal, but if they want to deploy the blog, it may cause issues with GitHub issues not showing on the page until that line is updated. This way, it is configurable.

Included in the PR are the following changes:

- Added `GH_USER_NAME` const to `siteconfig.js` and set it to the previously hardcoded GitHub username (Line 2).
- Changed the `allowedPosters` from the hardcoded GitHub username to the imported `GH_USER_NAME` from `siteconfig.js`.

Testing

- Switch to update-allowed-posters-in-content branch
- Run a `Git Pull` to pull in changes
- Run `npm install` to install deps
- Run `npm run start`
- Go to `http://localhost:3000/`
- Confirm you can pull in issues by going to the `Blog` page
