### PR TITLE
Change hardcoded title to variable

### DIFF
--- a/src/routes/blog.svelte
+++ b/src/routes/blog.svelte
@@ -1,4 +1,8 @@
 <script context="module">
+	import {
+		SITE_TITLE
+	} from '$lib/siteConfig';
+
 	// export const prerender = true; // turned off so it refreshes quickly
 	export async function load({ params, fetch }) {
 		const res = await fetch(`/api/listContent.json`);
@@ -48,7 +52,7 @@
 </script>
 
 <svelte:head>
-	<title>Swyxkit Blog Index</title>
+	<title>{SITE_TITLE}</title>
 	<meta name="description" content="Latest Hacker News stories in the {list} category" />
 </svelte:head>
 

--- a/src/routes/blog.svelte
+++ b/src/routes/blog.svelte
@@ -52,8 +52,8 @@
 </script>
 
 <svelte:head>
-	<title>{SITE_TITLE}</title>
-	<meta name="description" content="Latest Hacker News stories in the {list} category" />
+	<title>{SITE_TITLE} Blog Index</title>
+	<meta name="description" content={`Latest ${SITE_TITLE} posts`} />
 </svelte:head>
 
 <svelte:window on:keyup={focusSearch} />


### PR DESCRIPTION
I found that title of `/blog` is hardcoded. Therefore I changed it to variable from `siteConfig.js` just like other pages.