### PR TITLE
fix: Replace `maxage` with `cache` option

### DIFF
--- a/src/routes/[slug].svelte
+++ b/src/routes/[slug].svelte
@@ -21,7 +21,9 @@
 					slug,
 					REPO_URL
 				},
-				maxage: 60 // 1 minute
+				cache: {
+					maxage: 60 // 1 minute
+				}
 			};
 		} catch (err) {
 			console.error('error fetching blog post at [slug].svelte: ' + slug, res, err);

--- a/src/routes/blog.svelte
+++ b/src/routes/blog.svelte
@@ -15,7 +15,9 @@
 		const items = await res.json();
 		return {
 			props: { items },
-			maxage: 60 // 1 minute
+			cache: {
+				maxage: 60 // 1 minute
+			}
 		};
 	}
 </script>


### PR DESCRIPTION
This fixes a breaking change SvelteKit introduced in https://github.com/sveltejs/kit/issues/4549 where cache options have to be included inside a `cache` options object.

![error](https://user-images.githubusercontent.com/38083522/165561495-1bdffb31-556d-4f9d-9bf9-f7152f22a26b.png)
