### PR TITLE
Use GitHub API filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ export const DEFAULT_OG_IMAGE =
 export const MY_TWITTER_HANDLE = 'swyx';
 export const MY_YOUTUBE = 'https://youtube.com/swyxTV';
 export const POST_CATEGORIES = ['Blog']; // Other categories you can consider adding: Talks, Tutorials, Snippets, Podcasts, Notes...
+export const GH_PUBLISHED_TAGS = ['Published']; // List of allowed issue labels, only the issues having at least one of these labels will show on the blog.
 ```
 
 Of course, you should then go page by page (there aren't that many) and customize some of the other hardcoded items, for example
@@ -132,11 +133,11 @@ When deploying, don't forget to set it in Netlify: https://app.netlify.com/sites
 
 ### Step 2: Make your first post
 
-Open a new Github issue on your new repo, write some title and markdown in the body, **add a `Published` tag**, and then save.
+Open a new Github issue on your new repo, write some title and markdown in the body, **add a `Published` tag** (or any one of the label set in `GH_PUBLISHED_TAGS`), and then save.
 
 You should see it refetched in local dev or in the deployed site pretty quickly. You can configure Sveltekit to build each blog page up front, or on demand. Up to you to trade off speed and flexibility.
 
-If your `Published` post doesn't show up, you may have forgotten to set `APPROVED_POSTERS_GH_USERNAME` to your github username, as above.
+If your `Published` post (any post with one of the labels set in `GH_PUBLISHED_TAGS`) doesn't show up, you may have forgotten to set `APPROVED_POSTERS_GH_USERNAME` to your github username, as above.
 
 If all of this is annoying feel free to rip out the GitHub Issues CMS wiring and do your own content pipeline, I'm not your boss. MDSveX is already set up in this repo if you prefer not having a disconnected content toolchain from your codebase (which is fine, i just like having it in a different place for a better editing experience). See also my blogpost on [the benefits of using Github Issues as CMS](https://swyxkit.netlify.app/moving-to-a-github-cms).
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ export const DEFAULT_OG_IMAGE =
 	'https://user-images.githubusercontent.com/6764957/147861359-3ad9438f-41d1-47c8-aa05-95c7d18497f0.png';
 export const MY_TWITTER_HANDLE = 'swyx';
 export const MY_YOUTUBE = 'https://youtube.com/swyxTV';
-export const POST_CATEGORIES = ['Blog'] // Other categories you can consider adding: Talks, Tutorials, Snippets, Podcasts, Notes...
+export const POST_CATEGORIES = ['Blog']; // Other categories you can consider adding: Talks, Tutorials, Snippets, Podcasts, Notes...
 ```
 
 Of course, you should then go page by page (there aren't that many) and customize some of the other hardcoded items, for example

--- a/src/components/Comment.svelte
+++ b/src/components/Comment.svelte
@@ -46,18 +46,20 @@
 	// }
 </script>
 
-
 <div
 	class="mb-4 border-y-2 px-2 pt-4 dark:border-blue-700 sm:border-x sm:border-blue-200 sm:border-opacity-40 sm:px-4"
 >
-	<div class="flex flex-row md-10">
-		<img 
-			class="w-12 h-12 border-2 border-gray-300 rounded-full" 
+	<div class="md-10 flex flex-row">
+		<img
+			class="h-12 w-12 rounded-full border-2 border-gray-300"
 			alt={`avatar of commenter ${comment.user.login}`}
 			src={comment.user.avatar_url}
 		/>
-		<div class="flex-col mt-1">
-			<div class="flex items-center flex-1 px-4 font-bold leading-tight" class:text-green-600={comment.author_association === 'OWNER'}>
+		<div class="mt-1 flex-col">
+			<div
+				class="flex flex-1 items-center px-4 font-bold leading-tight"
+				class:text-green-600={comment.author_association === 'OWNER'}
+			>
 				{comment.user.login}
 				<span class="ml-2 text-xs font-normal text-gray-500">
 					<a href={comment.html_url} class="no-underline" rel="external" target="_blank">
@@ -65,11 +67,10 @@
 					</a>
 				</span>
 			</div>
-			<div class="flex-1 px-2 ml-2">
+			<div class="ml-2 flex-1 px-2">
 				{@html body}
-				
 			</div>
-			<div class="flex-1 px-2 ml-2 mb-4">
+			<div class="ml-2 mb-4 flex-1 px-2">
 				<Reactions issueUrl={comment.issue_url} reactions={comment.reactions} />
 			</div>
 		</div>

--- a/src/components/IndexCard.svelte
+++ b/src/components/IndexCard.svelte
@@ -2,7 +2,7 @@
 	// href={item.slug} title={item.data.title} date={item.data.date}
 	export let href = '#';
 	/** @type {import('$lib/types').ContentItem} */
-	export let item = undefined
+	export let item = undefined;
 	/** @type {import('$lib/types').GHMetadata} */
 	export let ghMetadata = null;
 	export let title = 'Untitled post';
@@ -23,20 +23,18 @@
 		<p class="text-gray-600 dark:text-gray-400">
 			<slot />
 		</p>
-		<div class="flex gap-4 text-left text-gray-500 md:mb-0 md:text-sm m-2">
+		<div class="m-2 flex gap-4 text-left text-gray-500 md:mb-0 md:text-sm">
 			<!-- {JSON.stringify(item.readingTime)} -->
 			<p>{stringData}</p>
 			{#if item?.readingTime}
 				<p>{item?.readingTime}</p>
 			{/if}
 			{#if ghMetadata && ghMetadata.reactions.total_count}
-				<p
-					class=""
-					>{ghMetadata.reactions.total_count} ♥</p
-				>
+				<p class="">{ghMetadata.reactions.total_count} ♥</p>
 			{/if}
-			<button class="rounded-xl px-4 bg-gray-200 dark:bg-gray-700 dark:text-gray-400 capitalize">{item?.category || 'blog'}</button>
-			
+			<button class="rounded-xl bg-gray-200 px-4 capitalize dark:bg-gray-700 dark:text-gray-400"
+				>{item?.category || 'blog'}</button
+			>
 		</div>
 	</div></a
 >

--- a/src/components/MobileMenu.svelte
+++ b/src/components/MobileMenu.svelte
@@ -44,7 +44,7 @@
 			>
 		{:else}
 			<svg
-				class="h-5 w-5 absolute text-gray-900 dark:text-gray-100"
+				class="absolute h-5 w-5 text-gray-900 dark:text-gray-100"
 				viewBox="0 0 24 24"
 				width="24"
 				height="24"

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -117,7 +117,7 @@
 					viewBox="0 0 24 24"
 					fill="none"
 					stroke="currentColor"
-					class="w-5 h-5 text-gray-800 dark:text-gray-200"
+					class="h-5 w-5 text-gray-800 dark:text-gray-200"
 				>
 					<path
 						stroke-linecap="round"

--- a/src/lib/+page.svelte
+++ b/src/lib/+page.svelte
@@ -12,14 +12,14 @@
 
 	// technically this is a slighlty different type because doesnt have 'content' but we'll let it slide
 	/** @type {import('$lib/types').ContentItem[]} */
-	$: items = data.items; 
+	$: items = data.items;
 
 	function searchParamToArray(key) {
 		return ($page.url.searchParams.get(key) || '').split(',').filter((e) => e);
 	}
 
-	let selectedCategories = searchParamToArray('show')
-	let search = $page.url.searchParams.get('filter') || ''
+	let selectedCategories = searchParamToArray('show');
+	let search = $page.url.searchParams.get('filter') || '';
 	let inputEl;
 
 	$: if (browser) {
@@ -43,13 +43,15 @@
 	let isTruncated = items?.length > 20;
 	$: list = items
 		.filter((item) => {
-				if (selectedCategories.length) {
-					return selectedCategories.map(
-						element => {return element.toLowerCase();}
-					).includes(item.category.toLowerCase());
-				}
-				return true
-			})
+			if (selectedCategories.length) {
+				return selectedCategories
+					.map((element) => {
+						return element.toLowerCase();
+					})
+					.includes(item.category.toLowerCase());
+			}
+			return true;
+		})
 		.filter((item) => {
 			if (search) {
 				return item.title.toLowerCase().includes(search.toLowerCase());
@@ -105,9 +107,14 @@
 					<input
 						id="category-{availableCategory}"
 						class="peer sr-only"
-						type="checkbox" bind:group={selectedCategories} value={availableCategory} 
+						type="checkbox"
+						bind:group={selectedCategories}
+						value={availableCategory}
 					/>
-					<label for="category-{availableCategory}" class="inline-flex justify-between items-center px-4 py-2 w-full text-gray-500 bg-white border border-gray-200 cursor-pointer dark:hover:text-gray-300 dark:border-gray-700 dark:peer-checked:text-purple-500 peer-checked:border-purple-600 peer-checked:text-purple-600 hover:text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:bg-gray-800 dark:hover:bg-gray-700">                           
+					<label
+						for="category-{availableCategory}"
+						class="inline-flex w-full cursor-pointer items-center justify-between border border-gray-200 bg-white px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-600 peer-checked:border-purple-600 peer-checked:text-purple-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-300 dark:peer-checked:text-purple-500"
+					>
 						{availableCategory}
 					</label>
 				</div>
@@ -165,7 +172,7 @@
 			No posts found for
 			<code>{search}</code>.
 		</div>
-		<button class="p-2 bg-slate-500" on:click={() => (search = '')}>Clear your search</button>
+		<button class="bg-slate-500 p-2" on:click={() => (search = '')}>Clear your search</button>
 	{:else}
 		<div class="prose dark:prose-invert">No blogposts found!</div>
 	{/if}

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -57,11 +57,10 @@ export async function listContent() {
 			state: 'all',
 			labels: GH_PUBLISHED_TAGS.toString(),
 			per_page: '100',
-			pulls: 'false'
 		});
 	// pull issues created by owner only if allowed author = repo owner
 	if (APPROVED_POSTERS_GH_USERNAME.length === 1 && APPROVED_POSTERS_GH_USERNAME[0] === REPO_OWNER) {
-		url += '&' + new URLSearchParams({ filter: 'created' });
+		url += '&' + new URLSearchParams({ creator: REPO_OWNER });
 	}
 	do {
 		const res = await fetch(next?.url ?? url, {

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -52,7 +52,7 @@ export async function listContent() {
 		Authorization: `token ${process.env.GH_TOKEN}`
 	};
 	let url =
-		`https://api.github.com/repos//${GH_USER_REPO}/issues?` +
+		`https://api.github.com/repos/${GH_USER_REPO}/issues?` +
 		new URLSearchParams({
 			state: 'all',
 			labels: GH_PUBLISHED_TAGS.toString(),

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -2,7 +2,12 @@ import { compile } from 'mdsvex';
 import { dev } from '$app/environment';
 import grayMatter from 'gray-matter';
 import fetch from 'node-fetch';
-import { GH_USER_REPO, APPROVED_POSTERS_GH_USERNAME } from './siteConfig';
+import {
+	GH_USER_REPO,
+	APPROVED_POSTERS_GH_USERNAME,
+	GH_PUBLISHED_TAGS,
+	REPO_OWNER
+} from './siteConfig';
 import parse from 'parse-link-header';
 import slugify from '@sindresorhus/slugify';
 import rehypeStringify from 'rehype-stringify';
@@ -22,8 +27,6 @@ const rehypePlugins = [
 	]
 ];
 
-const allowedPosters = APPROVED_POSTERS_GH_USERNAME; // array of strings of github username
-const publishedTags = ['Published'];
 let allBlogposts = [];
 // let etag = null // todo - implmement etag header
 ``;
@@ -32,9 +35,9 @@ let allBlogposts = [];
  * @param {string} text
  * @returns {string}
  */
- function readingTime(text) {
-    let minutes = Math.ceil(text.trim().split(' ').length / 225)
-    return minutes > 1 ? `${minutes} minutes` : `${minutes} minute`
+function readingTime(text) {
+	let minutes = Math.ceil(text.trim().split(' ').length / 225);
+	return minutes > 1 ? `${minutes} minutes` : `${minutes} minute`;
 }
 
 export async function listContent() {
@@ -48,13 +51,22 @@ export async function listContent() {
 	const authheader = process.env.GH_TOKEN && {
 		Authorization: `token ${process.env.GH_TOKEN}`
 	};
+	let url =
+		`https://api.github.com/repos//${GH_USER_REPO}/issues?` +
+		new URLSearchParams({
+			state: 'all',
+			labels: GH_PUBLISHED_TAGS.toString(),
+			per_page: '100',
+			pulls: 'false'
+		});
+	// pull issues created by owner only if allowed author = repo owner
+	if (APPROVED_POSTERS_GH_USERNAME.length === 1 && APPROVED_POSTERS_GH_USERNAME[0] === REPO_OWNER) {
+		url += '&' + new URLSearchParams({ filter: 'created' });
+	}
 	do {
-		const res = await fetch(
-			next?.url ?? `https://api.github.com/repos/${GH_USER_REPO}/issues?state=all&per_page=100`,
-			{
-				headers: authheader
-			}
-		);
+		const res = await fetch(next?.url ?? url, {
+			headers: authheader
+		});
 
 		const issues = await res.json();
 		if ('message' in issues && res.status > 400)
@@ -63,8 +75,9 @@ export async function listContent() {
 			/** @param {import('./types').GithubIssue} issue */
 			(issue) => {
 				if (
-					issue.labels.some((label) => publishedTags.includes(label.name)) &&
-					allowedPosters.includes(issue.user.login)
+					// labels check not needed anymore as we have set the labels param in github api
+					// issue.labels.some((label) => GH_PUBLISHED_TAGS.includes(label.name)) &&
+					APPROVED_POSTERS_GH_USERNAME.includes(issue.user.login)
 				) {
 					_allBlogposts.push(parseIssue(issue));
 				}
@@ -93,19 +106,16 @@ export async function getContent(slug) {
 	// find the blogpost that matches this slug
 	const blogpost = allBlogposts.find((post) => post.slug === slug);
 	if (blogpost) {
-
 		const blogbody = blogpost.content
-			.replace(
-				/\n{% youtube (.*?) %}/g,
-				(_, x) => {
-
-					// https://stackoverflow.com/a/27728417/1106414
-					function youtube_parser(url) {
-						var rx = /^.*(?:(?:youtu\.be\/|v\/|vi\/|u\/\w\/|embed\/)|(?:(?:watch)?\?v(?:i)?=|\&v(?:i)?=))([^#\&\?]*).*/;
-						return url.match(rx)[1]
-					}
-					const videoId = x.startsWith('https://') ? youtube_parser(x) : x;
-					return `<iframe
+			.replace(/\n{% youtube (.*?) %}/g, (_, x) => {
+				// https://stackoverflow.com/a/27728417/1106414
+				function youtube_parser(url) {
+					var rx =
+						/^.*(?:(?:youtu\.be\/|v\/|vi\/|u\/\w\/|embed\/)|(?:(?:watch)?\?v(?:i)?=|\&v(?:i)?=))([^#\&\?]*).*/;
+					return url.match(rx)[1];
+				}
+				const videoId = x.startsWith('https://') ? youtube_parser(x) : x;
+				return `<iframe
 			class="w-full object-contain"
 			srcdoc="
 				<style>
@@ -148,19 +158,16 @@ export async function getContent(slug) {
 			width="600"
 			height="400"
 			allowFullScreen
-			aria-hidden="true"></iframe>`}
-			)
-			.replace(
-				/\n{% (tweet|twitter) (.*?) %}/g,
-				(_, _2, x) => {
-					const url = x.startsWith('https://twitter.com/') ? x : `https://twitter.com/x/status/${x}`;
-					return `
+			aria-hidden="true"></iframe>`;
+			})
+			.replace(/\n{% (tweet|twitter) (.*?) %}/g, (_, _2, x) => {
+				const url = x.startsWith('https://twitter.com/') ? x : `https://twitter.com/x/status/${x}`;
+				return `
 					<blockquote class="twitter-tweet" data-lang="en" data-dnt="true" data-theme="dark">
 					<a href="${url}"></a></blockquote> 
 					<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-					`
-				}
-			);
+					`;
+			});
 
 		// compile it with mdsvex
 		const content = (
@@ -171,7 +178,7 @@ export async function getContent(slug) {
 		).code
 			// https://github.com/pngwn/MDsveX/issues/392
 			.replace(/>{@html `<code class="language-/g, '><code class="language-')
-			.replace(/<\/code>`}<\/pre>/g, '</code></pre>')
+			.replace(/<\/code>`}<\/pre>/g, '</code></pre>');
 
 		return { ...blogpost, content };
 	} else {

--- a/src/lib/siteConfig.js
+++ b/src/lib/siteConfig.js
@@ -1,14 +1,18 @@
 export const SITE_URL = 'https://swyxkit.netlify.app';
 export const APPROVED_POSTERS_GH_USERNAME = ['sw-yx'];
 export const GH_USER_REPO = 'sw-yx/swyxkit'; // used for pulling github issues and offering comments
-export const REPO_URL = 'https://github.com/' + GH_USER_REPO;
 export const SITE_TITLE = 'SwyxKit';
 export const SITE_DESCRIPTION = "swyx's default SvelteKit + Tailwind starter";
 export const DEFAULT_OG_IMAGE =
 	'https://user-images.githubusercontent.com/6764957/147861359-3ad9438f-41d1-47c8-aa05-95c7d18497f0.png';
 export const MY_TWITTER_HANDLE = 'swyx';
 export const MY_YOUTUBE = 'https://youtube.com/swyxTV';
-export const POST_CATEGORIES = ['Blog'] // Other categories you can consider adding: Talks, Tutorials, Snippets, Podcasts, Notes...
+export const POST_CATEGORIES = ['Blog']; // Other categories you can consider adding: Talks, Tutorials, Snippets, Podcasts, Notes...
+export const GH_PUBLISHED_TAGS = ['Published'];
+
+// auto generated variables
+export const REPO_URL = 'https://github.com/' + GH_USER_REPO;
+export const REPO_OWNER = GH_USER_REPO.split('/')[0];
 
 // dont forget process.env.GH_TOKEN
 // if supplied, raises rate limit from 60 to 5000

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -13,7 +13,7 @@ export type ContentItem = {
 	canonical: string;
 	slug: string;
 	date: Date;
-	readingTime: string,
+	readingTime: string;
 	ghMetadata: GHMetadata;
 };
 

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,7 +1,7 @@
 <script>
 	// import Nav from '../components/Nav.svelte';
 	import { dev } from '$app/environment';
-  import { page } from '$app/stores';
+	import { page } from '$app/stores';
 
 	const offline = typeof navigator !== 'undefined' && navigator.onLine === false;
 
@@ -27,7 +27,11 @@
 
 	{#if $page.status === 404}
 		<p class="">There is no post at the slug <code>{$page.url.pathname}</code>.</p>
-		<p><a href={'/blog/?filter=' + $page.url.pathname.slice(1)}>Try searching for "{displayPathname($page.url.pathname.slice(1))}" here!</a></p>
+		<p>
+			<a href={'/blog/?filter=' + $page.url.pathname.slice(1)}
+				>Try searching for "{displayPathname($page.url.pathname.slice(1))}" here!</a
+			>
+		</p>
 		<p class="">If you believe this was a bug, please let me know!</p>
 	{:else}
 		<p class="font-mono">{message}</p>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,7 +10,6 @@
 		MY_TWITTER_HANDLE
 	} from '$lib/siteConfig';
 	export const prerender = true; // index page is most visited, lets prerender
-
 </script>
 
 <svelte:head>
@@ -48,7 +47,11 @@
 			<h2 class="mb-4 text-gray-700 dark:text-gray-200">
 				An opinionated blog starter for <span class="font-semibold"
 					>SvelteKit + Tailwind + Netlify.</span
-				> Refreshed <a href="https://github.com/sveltejs/kit/discussions/5774">the great SvelteKit redesign of Summer 2022</a>
+				>
+				Refreshed
+				<a href="https://github.com/sveltejs/kit/discussions/5774"
+					>the great SvelteKit redesign of Summer 2022</a
+				>
 			</h2>
 			<p class="mb-16 text-gray-600 dark:text-gray-400">
 				<a href={REPO_URL}>View source here!</a>

--- a/src/routes/[slug]/+page.js
+++ b/src/routes/[slug]/+page.js
@@ -6,7 +6,7 @@ export async function load({ params, fetch, setHeaders }) {
 	let res = null;
 	res = await fetch(`/api/blog/${slug}.json`);
 	if (res.status > 400) {
-		throw error(res.status, await res.text())
+		throw error(res.status, await res.text());
 	}
 	setHeaders({
 		'cache-control': 'public, max-age=60'
@@ -15,7 +15,7 @@ export async function load({ params, fetch, setHeaders }) {
 		json: await res.json(),
 		slug,
 		REPO_URL
-	}
+	};
 	// } catch (err) {
 	// 	console.error('error fetching blog post at [slug].svelte: ' + slug, res, err);
 	// 	throw error(500, 'error fetching blog post at [slug].svelte: ' + slug + ': ' + res);

--- a/src/routes/api/blog/[slug].json/+server.js
+++ b/src/routes/api/blog/[slug].json/+server.js
@@ -14,6 +14,6 @@ export async function GET({ params }) {
 			}
 		});
 	} catch (err) {
-		throw error(404, err.message)
+		throw error(404, err.message);
 	}
 }

--- a/src/routes/api/listContent.json/+server.js
+++ b/src/routes/api/listContent.json/+server.js
@@ -8,10 +8,10 @@ export async function GET({ setHeaders }) {
 	const list = await listContent();
 	setHeaders({
 		'Cache-Control': `max-age=0, s-maxage=${60}` // 1 minute.. for now
-	})
+	});
 	return new Response(JSON.stringify(list), {
 		headers: {
 			'content-type': 'application/json; charset=utf-8'
 		}
-	})
+	});
 }

--- a/src/routes/blog/+page.js
+++ b/src/routes/blog/+page.js
@@ -1,4 +1,3 @@
-
 import { error } from '@sveltejs/kit';
 // export const prerender = true; // turned off so it refreshes quickly
 export async function load({ setHeaders, fetch }) {
@@ -6,13 +5,13 @@ export async function load({ setHeaders, fetch }) {
 	// alternate strategy https://www.davidwparker.com/posts/how-to-make-an-rss-feed-in-sveltekit
 	// Object.entries(import.meta.glob('./*.md')).map(async ([path, page]) => {
 	if (res.status > 400) {
-		throw error(res.status, await res.text())
+		throw error(res.status, await res.text());
 	}
 
 	/** @type {import('$lib/types').ContentItem[]} */
 	const items = await res.json();
 	setHeaders({
 		'cache-control': 'public, max-age=60' // 1 minute
-	})
-	return {items}
+	});
+	return { items };
 }

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -12,14 +12,14 @@
 
 	// technically this is a slighlty different type because doesnt have 'content' but we'll let it slide
 	/** @type {import('$lib/types').ContentItem[]} */
-	$: items = data.items; 
+	$: items = data.items;
 
 	function searchParamToArray(key) {
 		return ($page.url.searchParams.get(key) || '').split(',').filter((e) => e);
 	}
 
-	let selectedCategories = searchParamToArray('show')
-	let search = $page.url.searchParams.get('filter') || ''
+	let selectedCategories = searchParamToArray('show');
+	let search = $page.url.searchParams.get('filter') || '';
 	let inputEl;
 
 	$: if (browser) {
@@ -43,13 +43,15 @@
 	let isTruncated = items?.length > 20;
 	$: list = items
 		.filter((item) => {
-				if (selectedCategories.length) {
-					return selectedCategories.map(
-						element => {return element.toLowerCase();}
-					).includes(item.category.toLowerCase());
-				}
-				return true
-			})
+			if (selectedCategories.length) {
+				return selectedCategories
+					.map((element) => {
+						return element.toLowerCase();
+					})
+					.includes(item.category.toLowerCase());
+			}
+			return true;
+		})
 		.filter((item) => {
 			if (search) {
 				return item.title.toLowerCase().includes(search.toLowerCase());
@@ -105,9 +107,14 @@
 					<input
 						id="category-{availableCategory}"
 						class="peer sr-only"
-						type="checkbox" bind:group={selectedCategories} value={availableCategory} 
+						type="checkbox"
+						bind:group={selectedCategories}
+						value={availableCategory}
 					/>
-					<label for="category-{availableCategory}" class="inline-flex justify-between items-center px-4 py-2 w-full text-gray-500 bg-white border border-gray-200 cursor-pointer dark:hover:text-gray-300 dark:border-gray-700 dark:peer-checked:text-purple-500 peer-checked:border-purple-600 peer-checked:text-purple-600 hover:text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:bg-gray-800 dark:hover:bg-gray-700">                           
+					<label
+						for="category-{availableCategory}"
+						class="inline-flex w-full cursor-pointer items-center justify-between border border-gray-200 bg-white px-4 py-2 text-gray-500 hover:bg-gray-100 hover:text-gray-600 peer-checked:border-purple-600 peer-checked:text-purple-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-300 dark:peer-checked:text-purple-500"
+					>
 						{availableCategory}
 					</label>
 				</div>
@@ -166,7 +173,7 @@
 			No posts found for
 			<code>{search}</code>.
 		</div>
-		<button class="p-2 bg-slate-500" on:click={() => (search = '')}>Clear your search</button>
+		<button class="bg-slate-500 p-2" on:click={() => (search = '')}>Clear your search</button>
 	{:else}
 		<div class="prose dark:prose-invert">No blogposts found!</div>
 	{/if}

--- a/src/routes/rss.xml/+server.js
+++ b/src/routes/rss.xml/+server.js
@@ -4,7 +4,7 @@ import { listContent } from '$lib/content';
 
 // Reference: https://github.com/sveltejs/kit/blob/master/examples/hn.svelte.dev/src/routes/%5Blist%5D/rss.js
 /** @type {import('@sveltejs/kit').RequestHandler} */
-export async function GET({setHeaders}) {
+export async function GET({ setHeaders }) {
 	const feed = new RSS({
 		title: SITE_TITLE + ' RSS Feed',
 		site_url: SITE_URL,

--- a/src/routes/sitemap.xml/+server.js
+++ b/src/routes/sitemap.xml/+server.js
@@ -6,12 +6,12 @@ export async function GET() {
 	const pages = [`about`];
 	const body = sitemap(posts, pages);
 
-  return new Response(body, {
-    headers: {
-      'Cache-Control': `max-age=0, s-maxage=${3600}`,
-      'Content-Type': 'application/xml'
-    }
-  });
+	return new Response(body, {
+		headers: {
+			'Cache-Control': `max-age=0, s-maxage=${3600}`,
+			'Content-Type': 'application/xml'
+		}
+	});
 }
 
 const sitemap = (posts, pages) => `<?xml version="1.0" encoding="UTF-8" ?>

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,29 +1,29 @@
 import { expect, test } from '@playwright/test';
 
 test('about page has expected h1', async ({ page }) => {
-    await page.goto('/about');
-    expect(await page.textContent('h1')).toBe('About swyxkit!');
+	await page.goto('/about');
+	expect(await page.textContent('h1')).toBe('About swyxkit!');
 });
 
 test.describe('test blog page', () => {
-    test('blog page to preserve url params', async ({ page }) => {
-        // Go to http://localhost:4173/
-        await page.goto('/blog');
-    
-        // Click [placeholder="Hit \/ to search"]
-        await page.locator('[placeholder="Hit \\/ to search"]').click();
-    
-        // Fill [placeholder="Hit \/ to search"]
-        await page.locator('[placeholder="Hit \\/ to search"]').fill('test');
-        await expect(page).toHaveURL('http://localhost:4173/blog?filter=test');
-    
-        // Click label:has-text("Blog")
-        await page.locator('label:has-text("Blog")').click();
-        await expect(page).toHaveURL('http://localhost:4173/blog?filter=test&show=Blog');
-    });
-    
-    test('blog to honour existing params', async ({ page }) => {
-        await page.goto('http://localhost:4173/blog?filter=test&show=Blog');
-        await expect(page).toHaveURL('http://localhost:4173/blog?filter=test&show=Blog');
-    });
+	test('blog page to preserve url params', async ({ page }) => {
+		// Go to http://localhost:4173/
+		await page.goto('/blog');
+
+		// Click [placeholder="Hit \/ to search"]
+		await page.locator('[placeholder="Hit \\/ to search"]').click();
+
+		// Fill [placeholder="Hit \/ to search"]
+		await page.locator('[placeholder="Hit \\/ to search"]').fill('test');
+		await expect(page).toHaveURL('http://localhost:4173/blog?filter=test');
+
+		// Click label:has-text("Blog")
+		await page.locator('label:has-text("Blog")').click();
+		await expect(page).toHaveURL('http://localhost:4173/blog?filter=test&show=Blog');
+	});
+
+	test('blog to honour existing params', async ({ page }) => {
+		await page.goto('http://localhost:4173/blog?filter=test&show=Blog');
+		await expect(page).toHaveURL('http://localhost:4173/blog?filter=test&show=Blog');
+	});
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,8 +24,8 @@
 		"allowJs": true,
 		"checkJs": true,
 		"paths": {
-			"$lib":["src/lib"],
-			"$lib/*":["src/lib/*"]
+			"$lib": ["src/lib"],
+			"$lib/*": ["src/lib/*"]
 		}
 	},
 	"include": [

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,3 @@
-
 // vite.config.js
 import { sveltekit } from '@sveltejs/kit/vite';
 


### PR DESCRIPTION
Uses GitHub api filters to reduce number of api calls made.

Details of params added:

- [x] **labels** A list of allowed label names set `GH_PUBLISHED_TAGS` in `siteConfig`
- [x] **creator** No config required. If only the repo owner is allowed, use this filter to pull already filtered issues from GitHub API.

I was looking at the incorrect endpoint
- [x] ~~**filter** No config required. It's used if allowed authors is equal to repo owner, so we only pull issues created by owner.~~
- [x] ~~**pulls** No config required. Asks GitHub API to not return pull requests. By default, issues endpoint include pull requests.~~