### PR TITLE
fix sveltekit:prefetch changed to data-sveltekit-prefetch

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -25,7 +25,7 @@
 		</script>
 		%sveltekit.head%
 	</head>
-	<body class="vsc-initialized bg-white text-white dark:bg-gray-900 dark:text-black">
+	<body class="vsc-initialized bg-white text-white dark:bg-gray-900 dark:text-black" data-sveltekit-prefetch>
 		<div id="svelte">%sveltekit.body%</div>
 	</body>
 </html>

--- a/src/components/IndexCard.svelte
+++ b/src/components/IndexCard.svelte
@@ -11,7 +11,6 @@
 </script>
 
 <a
-	sveltekit:prefetch
 	class="w-full text-gray-900 hover:text-yellow-600 dark:text-gray-100 dark:hover:text-yellow-100"
 	{href}
 	><div class="mb-8 w-full">

--- a/src/components/MobileMenu.svelte
+++ b/src/components/MobileMenu.svelte
@@ -69,7 +69,6 @@
 			>
 				<a
 					class="flex w-auto pb-4"
-					sveltekit:prefetch
 					on:click={() => setTimeout(() => (isOpen = false), 300)}
 					href="/">Home</a
 				>
@@ -80,7 +79,6 @@
 			>
 				<a
 					class="flex w-auto pb-4"
-					sveltekit:prefetch
 					on:click={() => setTimeout(() => (isOpen = false), 300)}
 					href="/blog">Blog</a
 				>
@@ -91,7 +89,6 @@
 			>
 				<a
 					class="flex w-auto pb-4"
-					sveltekit:prefetch
 					on:click={() => setTimeout(() => (isOpen = false), 300)}
 					href="/about">About</a
 				>


### PR DESCRIPTION
- Removed `sveltekit:prefetch` from all a tags.
- Made prefetch available for all internal links by setting `data-sveltekit-prefetch` in body tag.
- If any link needs prefetch disabled, we can set `data-sveltekit-prefetch=""` to that specific a tag.