### PR TITLE
fix: don't update URL infinitely on blog index based on search params

### DIFF
--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -23,6 +23,7 @@
 	let inputEl;
 
 	$: if (browser) {
+		const initialParams = $page.url.searchParams.toString();
 		if (selectedCategories.length) {
 			$page.url.searchParams.set('show', selectedCategories.toString());
 		} else {
@@ -33,7 +34,10 @@
 		} else {
 			$page.url.searchParams.delete('filter');
 		}
-		goto(`?${$page.url.searchParams.toString()}`, { noscroll: true, keepfocus: true });
+		const newParams = $page.url.searchParams.toString();
+		if (newParams !== initialParams) {
+			goto(`?${$page.url.searchParams.toString()}`, { noscroll: true, keepfocus: true });
+		}
 	}
 
 	function focusSearch(e) {

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -36,7 +36,7 @@
 		}
 		const newParams = $page.url.searchParams.toString();
 		if (newParams !== initialParams) {
-			goto(`?${$page.url.searchParams.toString()}`, { noscroll: true, keepfocus: true });
+			goto(`?${newParams}`, { noscroll: true, keepfocus: true });
 		}
 	}
 


### PR DESCRIPTION
When cloning this repo according to the instructions and wiring it up to [my simple list of posts](https://github.com/martypenner/personal-blog/issues?q=is%3Aissue+is%3Aclosed), I noticed the cursor flickering when I navigated to the blog page and the browser would freeze. Turns out an infinite redirect was happening. This PR addresses that by only navigating when the search params have actually changed.